### PR TITLE
Add heap profiler to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Demo and detailed documentation: https://clinicjs.org/
 ```
 npm install -g clinic
 ```
+
 <br />
 
 ![Screenshots](tools.gif)
@@ -73,17 +74,17 @@ Currently the supported Node.js versions are `>= 10.12.0`.
 
 ## Examples and Demos
 
-- [A set of simple Doctor examples](https://github.com/nearform/node-clinic-doctor-examples)
-- [A set of simple Bubbleprof examples](https://github.com/nearform/node-clinic-bubbleprof-examples)
-- [A MongoDB-based Bubbleprof demo/example](https://github.com/nearform/node-clinic-bubbleprof-demo)
-- [A Flame demo/example](https://github.com/nearform/node-clinic-flame-demo)
+- [A set of simple Doctor examples](https://github.com/clinicjs/node-clinic-doctor-examples)
+- [A set of simple Bubbleprof examples](https://github.com/clinicjs/node-clinic-bubbleprof-examples)
+- [A MongoDB-based Bubbleprof demo/example](https://github.com/clinicjs/node-clinic-bubbleprof-demo)
+- [A Flame demo/example](https://github.com/clinicjs/node-clinic-flame-demo)
 
 ## Report an issue
 
 If you encounter any issue, feel free to send us an issue report at:
 
 ```
-https://github.com/nearform/node-clinic/issues
+https://github.com/clinicjs/node-clinic/issues
 ```
 
 ## More information
@@ -94,11 +95,13 @@ For more information use the `--help` option:
 clinic doctor --help
 clinic bubbleprof --help
 clinic flame --help
+clinic heapprofiler --help
 ```
 
-- The `doctor` functionality is provided by [Clinic.js Doctor](https://github.com/nearform/node-clinic-doctor).
-- The `bubbleprof` functionality is provided by [Clinic.js Bubbleprof](https://github.com/nearform/node-clinic-bubbleprof).
-- The `flame` functionality is provided by [Clinic.js Flame](https://github.com/nearform/node-clinic-flame).
+- The `doctor` functionality is provided by [Clinic.js Doctor](https://github.com/clinicjs/node-clinic-doctor).
+- The `bubbleprof` functionality is provided by [Clinic.js Bubbleprof](https://github.com/clinicjs/node-clinic-bubbleprof).
+- The `flame` functionality is provided by [Clinic.js Flame](https://github.com/clinicjs/node-clinic-flame).
+- The `heapprofiler` functionality is provided by [Clinic.js Heap Profiler](https://github.com/clinicjs/node-clinic-heap-profiler).
 
 ## Flags
 
@@ -116,9 +119,10 @@ clinic flame --help
 
 Each of the tools has a programmable interface which you can read about in their repos.
 
-- [Clinic.js Doctor](https://github.com/nearform/node-clinic-doctor)
-- [Clinic.js Bubbleprof](https://github.com/nearform/node-clinic-bubbleprof)
-- [Clinic.js Flame](https://github.com/nearform/node-clinic-flame)
+- [Clinic.js Doctor](https://github.com/clinicjs/node-clinic-doctor)
+- [Clinic.js Bubbleprof](https://github.com/clinicjs/node-clinic-bubbleprof)
+- [Clinic.js Flame](https://github.com/clinicjs/node-clinic-flame)
+- [Clinic.js Heap Profiler](https://github.com/clinicjs/node-clinic-heap-profiler)
 
 ## License
 
@@ -133,5 +137,5 @@ Each of the tools has a programmable interface which you can read about in their
 [lint-standard-url]: https://github.com/feross/standard
 [azure-status]: https://dev.azure.com/node-clinic/node-clinic/_apis/build/status/nearform.node-clinic
 [azure-url]: https://dev.azure.com/node-clinic/node-clinic/_build/latest?definitionId=1?branchName=master
-[NearForm]: https://www.nearform.com
+[nearform]: https://www.nearform.com
 [subarg]: https://npmjs.com/package/subarg

--- a/docs/clinic-flame.txt
+++ b/docs/clinic-flame.txt
@@ -26,12 +26,12 @@
   You can use the --autocannon flag to simulate load on your server.
   --autocannon accepts configuration for autocannon using "subarg" syntax:
 
-    <code>clinic doctor --autocannon [ -m POST /api/example ] -- node server.js</code>
+    <code>clinic flame --autocannon [ -m POST /api/example ] -- node server.js</code>
 
   When configuring --autocannon, the $PORT environment variable contains the
   port your server is listening on:
 
-    <code>clinic doctor --autocannon [ -m POST 'http://localhost:$PORT/?\$page=1' ] -- node server.js</code>
+    <code>clinic flame --autocannon [ -m POST 'http://localhost:$PORT/?\$page=1' ] -- node server.js</code>
 
   Note that dollar signs ($) appearing in the URL must be escaped, else they
   will be treated as environment variables as well.

--- a/docs/clinic-heap-profiler.txt
+++ b/docs/clinic-heap-profiler.txt
@@ -1,35 +1,37 @@
 
-  <title>Clinic.js BubbleProf</title> - v{{version}}
+  <title>Clinic.js Heap Profiler</title> - v{{version}}
 
-  <code>clinic bubbleprof</code> helps you find asynchronous bottlenecks and debug event loop blocking.
+  <code>clinic heapprofiler</code> helps you find memory leaks
+  by creating a flamegraph visualization that assists in identifying
+  function calls that may be leaking memory.
 
-  To run <code>clinic bubbleprof</code>
+  To run <code>clinic heapprofiler</code>
 
-    <code>clinic bubbleprof -- node server.js</code>
+    <code>clinic heapprofiler -- node server.js</code>
 
   Once you exit (Ctrl-C) the process, your report will open in a browser window. You can disable this behavior:
 
-    <code>clinic bubbleprof --open=false -- node server.js</code>
+    <code>clinic heapprofiler --open=false -- node server.js</code>
 
   If profiling on a server, it can be useful to only do data collection:
 
-    <code>clinic bubbleprof --collect-only -- node server.js</code>
+    <code>clinic heapprofiler --collect-only -- node server.js</code>
 
   You can then transfer the data and visualize it locally:
 
-    <code>clinic bubbleprof --visualize-only PID.clinic-bubbleprof-sample</code>
+    <code>clinic heapprofiler --visualize-only PID.clinic.heapprofile</code>
 
   You can use the --autocannon flag to simulate load on your server.
   --autocannon accepts configuration for autocannon using "subarg" syntax:
 
-    <code>clinic bubbleprof --autocannon [ -m POST /api/example ] -- node server.js</code>
+    <code>clinic heapprofiler --autocannon [ -m POST /api/example ] -- node server.js</code>
 
   When configuring --autocannon, the $PORT environment variable contains the
   port your server is listening on:
 
-    <code>clinic bubbleprof --autocannon [ -m POST 'http://localhost:$PORT/?\$page=1' ] -- node server.js</code>
+    <code>clinic heapprofiler --autocannon [ -m POST 'http://localhost:$PORT/?\$page=1' ] -- node server.js</code>
 
-  Note that dollar signs (`$`) appearing in the URL must be escaped (`\$`), else they
+  Note that dollar signs ($) appearing in the URL must be escaped, else they
   will be treated as environment variables as well.
 
   <h1>Flags</h1>

--- a/docs/clinic.txt
+++ b/docs/clinic.txt
@@ -38,6 +38,7 @@
     <code>clinic bubbleprof --help</code>
     <code>clinic clean --help</code>
     <code>clinic flame --help</code>
+    <code>clinic heapprofiler --help</code>
 
   <h1>Flags</h1>
   -h | --help                Display Help

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "clinic",
   "description": "Clinic.js diagnoses your performance issues",
   "repository": "nearform/node-clinic",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "engines": {
     "node": "^14.0.0 || ^13.0.0 || ^12.0.0 || ^11.0.0 || ^10.12.0"
   },
@@ -21,6 +21,7 @@
     "@nearform/bubbleprof": "^6.0.1",
     "@nearform/doctor": "^7.0.1",
     "@nearform/flame": "^8.0.1",
+    "@nearform/heap-profiler": "^1.0.0",
     "any-shell-escape": "^0.1.1",
     "async": "^3.0.1",
     "autocannon": "^6.5.0",

--- a/test/cli-bubbleprof-non-node.test.js
+++ b/test/cli-bubbleprof-non-node.test.js
@@ -4,7 +4,7 @@ const test = require('tap').test
 const cli = require('./cli.js')
 
 test('clinic bubbleprof - should error early if non-node script', function (t) {
-  cli({}, ['clinic', 'bubbleprof', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+  cli({ relayStderr: false }, ['clinic', 'bubbleprof', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
     t.strictDeepEqual(err, new Error('process exited with exit code 1'))
     t.ok(/Clinic.js BubbleProf[^\w ]/.test(stdout.split('\n')[1]))
     t.end()
@@ -12,7 +12,7 @@ test('clinic bubbleprof - should error early if non-node script', function (t) {
 })
 
 test('clinic bubbleprof --collect-only - should error early if non-node script', function (t) {
-  cli({}, ['clinic', 'bubbleprof', '--collect-only', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+  cli({ relayStderr: false }, ['clinic', 'bubbleprof', '--collect-only', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
     t.strictDeepEqual(err, new Error('process exited with exit code 1'))
     t.ok(/Clinic.js BubbleProf[^\w ]/.test(stdout.split('\n')[1]))
     t.end()
@@ -20,7 +20,7 @@ test('clinic bubbleprof --collect-only - should error early if non-node script',
 })
 
 test('clinic bubbleprof - should accept full path to node.js', function (t) {
-  cli({}, ['clinic', 'bubbleprof', '--no-open', '--', process.execPath, '-e', 'setTimeout(() => {}, 10)'], function (err, stdout) {
+  cli({ relayStderr: false }, ['clinic', 'bubbleprof', '--no-open', '--', process.execPath, '-e', 'setTimeout(() => {}, 10)'], function (err, stdout) {
     t.ifError(err)
     t.ok(/Generated HTML file is (.*?)\.clinic[/\\](\d+).clinic-bubbleprof/.test(stdout))
     t.end()

--- a/test/cli-bubbleprof-visualize-only.test.js
+++ b/test/cli-bubbleprof-visualize-only.test.js
@@ -43,7 +43,7 @@ test('clinic bubbleprof --collect-only - missing data', function (t) {
   ], function (err, stdout, stderr) {
     t.strictDeepEqual(err, new Error('process exited with exit code 1'))
     t.strictEqual(stdout, '')
-    t.ok(stderr.includes(`Unknown argument "${arg}". Pattern: {pid}.clinic-{command}`))
+    t.ok(stderr.includes('No data found.'))
     t.end()
   })
 })

--- a/test/cli-doctor-non-node.test.js
+++ b/test/cli-doctor-non-node.test.js
@@ -4,7 +4,7 @@ const test = require('tap').test
 const cli = require('./cli.js')
 
 test('clinic doctor - should error early if non-node script', function (t) {
-  cli({}, ['clinic', 'doctor', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+  cli({ relayStderr: false }, ['clinic', 'doctor', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
     t.strictDeepEqual(err, new Error('process exited with exit code 1'))
     t.ok(/Clinic.js Doctor[^\w ]/.test(stdout.split('\n')[1]))
     t.end()
@@ -12,7 +12,7 @@ test('clinic doctor - should error early if non-node script', function (t) {
 })
 
 test('clinic doctor --collect-only - should error early if non-node script', function (t) {
-  cli({}, ['clinic', 'doctor', '--collect-only', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+  cli({ relayStderr: false }, ['clinic', 'doctor', '--collect-only', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
     t.strictDeepEqual(err, new Error('process exited with exit code 1'))
     t.ok(/Clinic.js Doctor[^\w ]/.test(stdout.split('\n')[1]))
     t.end()
@@ -20,7 +20,7 @@ test('clinic doctor --collect-only - should error early if non-node script', fun
 })
 
 test('clinic doctor - should accept full path to node.js', function (t) {
-  cli({}, ['clinic', 'doctor', '--no-open', '--', process.execPath, '-e', 'setTimeout(() => {}, 10)'], function (err, stdout) {
+  cli({ relayStderr: false }, ['clinic', 'doctor', '--no-open', '--', process.execPath, '-e', 'setTimeout(() => {}, 10)'], function (err, stdout) {
     t.ifError(err)
     t.ok(/Generated HTML file is (.*?)\.clinic[/\\](\d+).clinic-doctor/.test(stdout))
     t.end()

--- a/test/cli-doctor-visualize-only.test.js
+++ b/test/cli-doctor-visualize-only.test.js
@@ -43,7 +43,7 @@ test('clinic doctor --visualize-only - missing data', function (t) {
   ], function (err, stdout, stderr) {
     t.strictDeepEqual(err, new Error('process exited with exit code 1'))
     t.strictEqual(stdout, '')
-    t.ok(stderr.includes(`Unknown argument "${arg}". Pattern: {pid}.clinic-{command}`))
+    t.ok(stderr.includes('No data found.'))
     t.end()
   })
 })

--- a/test/cli-flame-non-node.test.js
+++ b/test/cli-flame-non-node.test.js
@@ -4,7 +4,7 @@ const test = require('tap').test
 const cli = require('./cli.js')
 
 test('clinic flame - should error early if non-node script', function (t) {
-  cli({}, ['clinic', 'flame', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+  cli({ relayStderr: false }, ['clinic', 'flame', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
     t.strictDeepEqual(err, new Error('process exited with exit code 1'))
     t.ok(/Clinic.js Flame[^\w ]/.test(stdout.split('\n')[1]))
     t.end()
@@ -12,7 +12,7 @@ test('clinic flame - should error early if non-node script', function (t) {
 })
 
 test('clinic flame --collect-only - should error early if non-node script', function (t) {
-  cli({}, ['clinic', 'flame', '--collect-only', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+  cli({ relayStderr: false }, ['clinic', 'flame', '--collect-only', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
     t.strictDeepEqual(err, new Error('process exited with exit code 1'))
     t.ok(/Clinic.js Flame[^\w ]/.test(stdout.split('\n')[1]))
     t.end()
@@ -20,7 +20,7 @@ test('clinic flame --collect-only - should error early if non-node script', func
 })
 
 test('clinic flame - should accept full path to node.js', function (t) {
-  cli({}, ['clinic', 'flame', '--no-open', '--', process.execPath, '-e', 'setTimeout(() => {}, 10)'], function (err, stdout) {
+  cli({ relayStderr: false }, ['clinic', 'flame', '--no-open', '--', process.execPath, '-e', 'setTimeout(() => {}, 10)'], function (err, stdout) {
     t.ifError(err)
     t.ok(/Generated HTML file is (.*?)\.clinic[/\\](\d+).clinic-flame/.test(stdout))
     t.end()

--- a/test/cli-flame-visualize-only.test.js
+++ b/test/cli-flame-visualize-only.test.js
@@ -43,7 +43,7 @@ test('clinic flame --visualize-only - missing data', function (t) {
   ], function (err, stdout, stderr) {
     t.strictDeepEqual(err, new Error('process exited with exit code 1'))
     t.strictEqual(stdout, '')
-    t.ok(stderr.includes(`Unknown argument "${arg}". Pattern: {pid}.clinic-{command}`))
+    t.ok(stderr.includes('No data found.'))
     t.end()
   })
 })

--- a/test/cli-heapprofiler-full.test.js
+++ b/test/cli-heapprofiler-full.test.js
@@ -1,0 +1,151 @@
+'use strict'
+
+const url = require('url')
+const fs = require('fs')
+const path = require('path')
+const async = require('async')
+const test = require('tap').test
+const cli = require('./cli.js')
+
+test('clinic heapprofiler -- node - no issues', function (t) {
+  // collect data
+  cli(
+    {},
+    ['clinic', 'heapprofiler', '--no-open', '--', 'node', '-e', 'require("util").inspect(process)'],
+    function (err, stdout, stderr, tempdir) {
+      t.ifError(err)
+
+      const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-heapprofile)/)[1]
+      const fullpath = url.pathToFileURL(fs.realpathSync(path.resolve(tempdir, dirname)))
+
+      t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${fullpath}.html`)
+
+      // check that files exists
+      async.parallel(
+        {
+          sourceData (done) {
+            fs.access(path.resolve(tempdir, dirname), done)
+          },
+          htmlFile (done) {
+            fs.access(path.resolve(tempdir, dirname + '.html'), done)
+          }
+        },
+        function (err) {
+          t.ifError(err)
+          t.end()
+        }
+      )
+    }
+  )
+})
+
+test('clinic heapprofiler -- node - bad status code', function (t) {
+  // collect data
+  cli(
+    { relayStderr: true },
+    ['clinic', 'heapprofiler', '--no-open', '--', 'node', '-e', 'process.exitCode = 1'],
+    function (err, stdout, stderr, tempdir) {
+      t.ifError(err)
+      const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-heapprofile)/)[1]
+      const fullpath = url.pathToFileURL(fs.realpathSync(path.resolve(tempdir, dirname)))
+
+      t.strictEqual(stdout.split('\n')[2], `Generated HTML file is ${fullpath}.html`)
+
+      // check that files exists
+      async.parallel(
+        {
+          sourceData (done) {
+            fs.access(path.resolve(tempdir, dirname), done)
+          },
+          htmlFile (done) {
+            fs.access(path.resolve(tempdir, dirname + '.html'), done)
+          }
+        },
+        function (err) {
+          t.ifError(err)
+          t.end()
+        }
+      )
+    }
+  )
+})
+
+test('clinic heapprofiler --on-port', function (t) {
+  cli(
+    { relayStderr: false },
+    [
+      'clinic',
+      'heapprofiler',
+      '--no-open',
+      '--on-port',
+      'autocannon localhost:$PORT -d 2',
+      '--',
+      'node',
+      path.join(__dirname, 'server.js')
+    ],
+    function (err, stdout, stderr, tempdir) {
+      t.ifError(err)
+
+      const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-heapprofile)/)[1]
+      const fullpath = url.pathToFileURL(fs.realpathSync(path.resolve(tempdir, dirname)))
+
+      t.ok(stderr.indexOf('Running 2s test @ http://localhost:') > -1)
+      t.strictEqual(stdout.split('\n')[0], 'Analysing data')
+      t.strictEqual(stdout.split('\n')[1], `Generated HTML file is ${fullpath}.html`)
+      t.end()
+    }
+  )
+})
+
+test('clinic heapprofiler --autocannon', function (t) {
+  cli(
+    { relayStderr: false },
+    [
+      'clinic',
+      'heapprofiler',
+      '--no-open',
+      // this defaults to 10s which is a long time but need to make sure that
+      // using this flag without [] works
+      '--autocannon',
+      '/test',
+      '--',
+      'node',
+      path.join(__dirname, 'server.js')
+    ],
+    function (err, stdout, stderr, tempdir) {
+      t.ifError(err)
+
+      const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-heapprofile)/)[1]
+      const fullpath = url.pathToFileURL(fs.realpathSync(path.resolve(tempdir, dirname)))
+
+      t.ok(stderr.indexOf('Running 10s test @ http://localhost:') > -1)
+      t.strictEqual(stdout.split('\n')[0], 'Analysing data')
+      t.strictEqual(stdout.split('\n')[1], `Generated HTML file is ${fullpath}.html`)
+      t.end()
+    }
+  )
+})
+
+test('clinic heapprofiler -- node - configure output destination', function (t) {
+  cli(
+    { relayStderr: false },
+    [
+      'clinic',
+      'heapprofiler',
+      '--no-open',
+      '--dest',
+      'test-heapprofiler-destination.clinic-heapprofile',
+      '--',
+      'node',
+      '-e',
+      'require("util").inspect(process)'
+    ],
+    function (err, stdout, stderr, tempdir) {
+      t.ifError(err)
+
+      t.ok(fs.statSync(path.join(tempdir, 'test-heapprofiler-destination.clinic-heapprofile')).isFile())
+      t.ok(fs.statSync(path.join(tempdir, 'test-heapprofiler-destination.clinic-heapprofile.html')).isFile())
+      t.end()
+    }
+  )
+})

--- a/test/cli-heapprofiler-help.test.js
+++ b/test/cli-heapprofiler-help.test.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const test = require('tap').test
+const cli = require('./cli.js')
+
+test('clinic heapprofiler --help', function (t) {
+  cli({}, ['clinic', 'heapprofiler', '--help'], function (err, stdout) {
+    t.ifError(err)
+    t.ok(/Clinic.js Heap Profiler[^\w ]/.test(stdout.split('\n')[1]))
+    t.end()
+  })
+})
+
+test('clinic heapprofiler -h', function (t) {
+  cli({}, ['clinic', 'heapprofiler', '-h'], function (err, stdout) {
+    t.ifError(err)
+    t.ok(/Clinic.js Heap Profiler[^\w ]/.test(stdout.split('\n')[1]))
+    t.end()
+  })
+})

--- a/test/cli-heapprofiler-no-args.test.js
+++ b/test/cli-heapprofiler-no-args.test.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const test = require('tap').test
+const cli = require('./cli.js')
+
+test('clinic heapprofiler', function (t) {
+  cli({}, ['clinic', 'heapprofiler'], function (err, stdout) {
+    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
+    t.ok(/Clinic.js Heap Profiler[^\w ]/.test(stdout.split('\n')[1]))
+    t.end()
+  })
+})

--- a/test/cli-heapprofiler-non-node.test.js
+++ b/test/cli-heapprofiler-non-node.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const test = require('tap').test
+const cli = require('./cli.js')
+
+test('clinic heapprofiler - should error early if non-node script', function (t) {
+  cli({ relayStderr: false }, ['clinic', 'heapprofiler', '--', 'sh', 'wrapper.sh'], function (err, stdout) {
+    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
+    t.ok(/Clinic.js Heap Profiler[^\w ]/.test(stdout.split('\n')[1]))
+    t.end()
+  })
+})
+
+test('clinic heapprofiler --collect-only - should error early if non-node script', function (t) {
+  cli(
+    { relayStderr: false },
+    ['clinic', 'heapprofiler', '--collect-only', '--', 'sh', 'wrapper.sh'],
+    function (err, stdout) {
+      t.strictDeepEqual(err, new Error('process exited with exit code 1'))
+      t.ok(/Clinic.js Heap Profiler[^\w ]/.test(stdout.split('\n')[1]))
+      t.end()
+    }
+  )
+})
+
+test('clinic heapprofiler - should accept full path to node.js', function (t) {
+  cli(
+    { relayStderr: false },
+    ['clinic', 'heapprofiler', '--no-open', '--', process.execPath, '-e', 'setTimeout(() => {}, 10)'],
+    function (err, stdout) {
+      t.ifError(err)
+      t.ok(/Generated HTML file is (.*?)\.clinic[/\\](\d+).clinic-heapprofile/.test(stdout))
+      t.end()
+    }
+  )
+})

--- a/test/cli-heapprofiler-version.test.js
+++ b/test/cli-heapprofiler-version.test.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const test = require('tap').test
+const cli = require('./cli.js')
+
+test('clinic heapprofiler --version', function (t) {
+  cli({}, ['clinic', 'heapprofiler', '--version'], function (err, stdout) {
+    t.ifError(err)
+    t.strictEqual(stdout, `v${require('@nearform/heap-profiler/package.json').version}\n`)
+    t.end()
+  })
+})
+
+test('clinic heapprofiler -v', function (t) {
+  cli({}, ['clinic', 'heapprofiler', '-v'], function (err, stdout) {
+    t.ifError(err)
+    t.strictEqual(stdout, `v${require('@nearform/heap-profiler/package.json').version}\n`)
+    t.end()
+  })
+})

--- a/test/cli-heapprofiler-visualize-only.test.js
+++ b/test/cli-heapprofiler-visualize-only.test.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const url = require('url')
+const fs = require('fs')
+const path = require('path')
+const test = require('tap').test
+const cli = require('./cli.js')
+
+test('clinic heapprofiler --visualize-only - no issues', function (t) {
+  // collect data
+  cli(
+    {},
+    ['clinic', 'heapprofiler', '--collect-only', '--', 'node', '-e', 'require("util").inspect(process)'],
+    function (err, stdout, stderr, tempdir) {
+      t.ifError(err)
+      t.ok(/Output file is \.clinic[/\\](\d+).clinic-heapprofile/.test(stdout))
+
+      const dirname = stdout.match(/(\.clinic[/\\]\d+.clinic-heapprofile)/)[1]
+      const dirpath = path.resolve(tempdir, dirname)
+
+      // visualize data
+      cli({}, ['clinic', 'heapprofiler', '--visualize-only', dirpath], function (err, stdout) {
+        t.ifError(err)
+        t.strictEqual(stdout.trim(), `Generated HTML file is ${url.pathToFileURL(dirpath)}.html`)
+
+        // check that HTML file exists
+        fs.access(dirpath + '.html', function (err) {
+          t.ifError(err)
+          t.end()
+        })
+      })
+    }
+  )
+})
+
+test('clinic heapprofiler --visualize-only - missing data', function (t) {
+  const arg = 'missing.clinic-heapprofile'
+  cli({ relayStderr: false }, ['clinic', 'heapprofiler', '--visualize-only', arg], function (err, stdout, stderr) {
+    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
+    t.strictEqual(stdout, '')
+    t.ok(stderr.includes('No data found.'))
+    t.end()
+  })
+})
+
+test('clinic heapprofiler --visualize-only - supports trailing slash', function (t) {
+  // collect data
+  cli(
+    {},
+    ['clinic', 'heapprofiler', '--collect-only', '--', 'node', '-e', 'require("util").inspect(process)'],
+    function (err, stdout, stderr, tempdir) {
+      t.ifError(err)
+      t.ok(/Output file is \.clinic[/\\](\d+).clinic-heapprofile/.test(stdout))
+      const filename = stdout.match(/(\.clinic[/\\]\d+.clinic-heapprofile)/)[1]
+      const dirpath = path.resolve(tempdir, filename)
+
+      // visualize data
+      cli({}, ['clinic', 'heapprofiler', '--visualize-only', `${dirpath}${path.sep}`], function (err, stdout) {
+        t.ifError(err)
+        t.strictEqual(stdout.trim(), `Generated HTML file is ${url.pathToFileURL(dirpath)}.html`)
+
+        // check that HTML file exists
+        fs.access(dirpath + '.html', function (err) {
+          t.ifError(err)
+          t.end()
+        })
+      })
+    }
+  )
+})


### PR DESCRIPTION
## What's in there?

This PR add support for the Heap Profiler and memory flame charts via https://github.com/clinicjs/node-clinic-heap-profiler.

## Notes to reviewers

This PR cannot be merged until https://github.com/clinicjs/node-clinic-heap-profiler/pull/1 lands and the package is finally released on NPM.