### PR TITLE
chore: add tags to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ typings/
 .vscode
 # IntelliJ Idea
 .idea
+
+# ctags
+tags


### PR DESCRIPTION
The `ctags`(used for jump into definitions﻿) create a `tags` file for cache
