### PR TITLE
bump insight@0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dargs": "^7.0.0",
     "env-string": "^1.0.1",
     "execspawn": "^1.0.1",
-    "insight": "^0.10.1",
+    "insight": "^0.11.1",
     "minimist": "^1.2.0",
     "open": "^7.3.0",
     "ora": "^5.1.0",


### PR DESCRIPTION
Fixes runtime issue on latest macOS

❯  clinic flame -- node dist/index.js
/Users/tjmehta/Developer/@codeshare/api/node_modules/macos-release/index.js:26
	const [name, version] = nameMap.get(release);
	                        ^

TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))