### PR TITLE
chore: Use cache in `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Check linting
         run: npm run ci-lint
 
@@ -32,8 +33,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version}}
+          cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install global dependencies
         run: npm install autocannon -g


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Details

Updated `ci.yml` to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### AS-IS

```yml
- name: Install Node.js 18
  uses: actions/setup-node@v3
  with:
    node-version: 18

- name: Install dependencies
  run: npm install
```

### TO-BE

```yml
- name: Install Node.js 18
  uses: actions/setup-node@v3
  with:
    node-version: 18
    cache: npm

- name: Install dependencies
  run: npm ci
```

> It’s literally a one line change to pass the `cache: npm` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)
