### PR TITLE
workflow: add workflow_dispatch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    - main
+  pull_request:
+  workflow_dispatch:
 
 name: CI
 
@@ -23,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [14, 16, 18]
+        node-version: [14, 16, 18, 19]
 
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
This is useful to run the CI when the data source isn't actively maintained. 