### PR TITLE
feat: accept --name argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ clinic heapprofiler --help
 --autocannon               Run the autocannon benchmarking tool when the server starts listening on a port.
 --dest                     Destination for the collect data (default .).
 --stop-delay               Add a delay to close the process when a job is done through either `autocannon` or `on-port` flag (milliseconds)
+--name                     The --name flag sets a name for the output data, allowing you to replace existing reports without generating new ones. Example: <code>.clinic/node-19-test.clinic-flame</code>
 ```
 
 ## Programmable Interfaces

--- a/bin.js
+++ b/bin.js
@@ -77,7 +77,8 @@ const result = commist()
         'sample-interval',
         'on-port',
         'dest',
-        'stop-delay'
+        'stop-delay',
+        'name'
       ],
       default: {
         'sample-interval': '10',
@@ -119,7 +120,8 @@ const result = commist()
       string: [
         'visualize-only',
         'dest',
-        'stop-delay'
+        'stop-delay',
+        'name'
       ],
       default: {
         open: true,
@@ -161,7 +163,8 @@ const result = commist()
       string: [
         'visualize-only',
         'dest',
-        'stop-delay'
+        'stop-delay',
+        'name'
       ],
       default: {
         open: true,
@@ -202,7 +205,8 @@ const result = commist()
       string: [
         'visualize-only',
         'dest',
-        'stop-delay'
+        'stop-delay',
+        'name'
       ],
       default: {
         open: true,
@@ -323,7 +327,8 @@ async function runTool (toolName, Tool, version, args, uiOptions) {
     detectPort: !!onPort,
     dest: args.dest,
     debug: args.debug,
-    kernelTracing: args['kernel-tracing']
+    kernelTracing: args['kernel-tracing'],
+    name: args.name
   })
 
   const stopDelayMs = parseInt(args['stop-delay'])

--- a/docs/clinic-bubbleprof.txt
+++ b/docs/clinic-bubbleprof.txt
@@ -42,3 +42,4 @@
   --open                     Boolean to enable or disable your report opening in your web browser.
   --dest                     Destination for the collected data (default <code>.clinic/</code>).
   --stop-delay               Add a delay to close the process when a job is done through either `autocannon` or `on-port` flag (milliseconds)
+  --name                     The --name flag sets a name for the output data, allowing you to replace existing reports without generating new ones. Example: <code>.clinic/node-19-test.clinic-flame</code>

--- a/docs/clinic-doctor.txt
+++ b/docs/clinic-doctor.txt
@@ -45,3 +45,4 @@
   --open                     Boolean to enable or disable your report opening in your web browser.
   --dest                     Destination for the collected data (default <code>.clinic/</code>).
   --stop-delay               Add a delay to close the process when a job is done through either `autocannon` or `on-port` flag (milliseconds)
+  --name                     The --name flag sets a name for the output data, allowing you to replace existing reports without generating new ones. Example: <code>.clinic/node-19-test.clinic-flame</code>

--- a/docs/clinic-flame.txt
+++ b/docs/clinic-flame.txt
@@ -51,3 +51,4 @@
   --dest                     Destination for the collected data (default <code>.clinic/</code>).
   --kernel-tracing            Profile application using linux_perf (linux only).
   --stop-delay               Add a delay to close the process when a job is done through either `autocannon` or `on-port` flag (milliseconds)
+  --name                     The --name flag sets a name for the output data, allowing you to replace existing reports without generating new ones. Example: <code>.clinic/node-19-test.clinic-flame</code>

--- a/docs/clinic-heap-profiler.txt
+++ b/docs/clinic-heap-profiler.txt
@@ -44,3 +44,4 @@
   --open                     Boolean to enable or disable your report opening in your web browser.
   --dest                     Destination for the collected data (default <code>.clinic/</code>).
   --stop-delay               Add a delay to close the process when a job is done through either `autocannon` or `on-port` flag (milliseconds)
+  --name                     The --name flag sets a name for the output data, allowing you to replace existing reports without generating new ones. Example: <code>.clinic/node-19-test.clinic-flame</code>


### PR DESCRIPTION
This introduces a new CLI flag, `--name`. It allows the user to specify an identifier for their report. For instance, let's imagine you are profiling a Node.js 18 app and performing the improvements on the flight. 

```console
$ clinic flame --name v18-test --autocannon [ / ] -- node index.js
```

It will generate the following tree:

```console
.clinic
├── v18-test.clinic-flame
│   ├── v18-test.clinic-flame-inlinedfunctions
│   ├── v18-test.clinic-flame-samples
│   └── v18-test.clinic-flame-systeminfo
└── v18-test.clinic-flame.html
```

And every time I run the clinic flame script, it will update the current file (`v18-test.clinic-flame*`), so I just need to reload my .html page.